### PR TITLE
Exclude conflicting bouncycastle lib from new dependency

### DIFF
--- a/services/pom.xml
+++ b/services/pom.xml
@@ -96,6 +96,10 @@
                     <groupId>org.glassfish</groupId>
                     <artifactId>jakarta.json</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcprov-jdk18on</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <!-- lazy dev -->


### PR DESCRIPTION
The danubetech verifiable-credentials-java dependency is pulling in a conflicting bouncy castle lib (bcprov-jdk18on) which is causing the fips1402 package to fail compilation as it requires the fips version of bouncy castle.
 